### PR TITLE
spring-dotenv config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Environment specific files ###
+src/main/resources/.env

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>springfox-swagger-ui</artifactId>
             <version>2.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>me.paulschwarz</groupId>
+            <artifactId>spring-dotenv</artifactId>
+            <version>2.5.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/br/dh/meli/integratorprojectfresh/IntegratorProjectFreshApplication.java
+++ b/src/main/java/br/dh/meli/integratorprojectfresh/IntegratorProjectFreshApplication.java
@@ -1,13 +1,28 @@
 package br.dh.meli.integratorprojectfresh;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class IntegratorProjectFreshApplication {
+public class IntegratorProjectFreshApplication implements ApplicationRunner {
+    private static final Logger logger = LoggerFactory.getLogger(IntegratorProjectFreshApplication.class);
+
+    @Value("${env.APP_MELI_FRESH}") String profile;
 
     public static void main(String[] args) {
         SpringApplication.run(IntegratorProjectFreshApplication.class, args);
     }
 
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        logger.info("Application started with command-line arguments: {}", args.getOptionNames());
+        logger.info("NonOptionArgs: {}", args.getNonOptionArgs());
+        logger.info("OptionNames: {}", args.getOptionNames());
+        logger.info("Active profile: {}", profile);
+    }
 }

--- a/src/main/resources/.env.example
+++ b/src/main/resources/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env and fill in your values.
+# Don't forget to add .env to your .gitignore file.
+
+APP_MELI_FRESH=
+APP_DB_USERNAME=
+APP_DB_PASSWORD=
+APP_DB_DEV_URL=
+APP_DB_TEST_URL=

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,22 +1,20 @@
-# 1 - usu√°rio do BD
-spring.datasource.username = ${APP_DB_USER}
+# usu·rio do BD
+spring.datasource.username = ${env.APP_DB_USERNAME}
 
-# 2 - senha do BD
+# senha do BD
+spring.datasource.password = ${env.APP_DB_PASSWORD}
 
-spring.datasource.password = ${APP_DB_PASSWORD}
+# string de conex„o com o BD / Cria o BD se n„o existir
+spring.datasource.url = ${env.APP_DB_DEV_URL}
 
-
-# 3 - string de conex√£o com o BD / Cria o BD se n√£o existir
-spring.datasource.url = jdbc:mysql://localhost:3306/meli_fresh?createDatabaseIfNotExist=true
-
-# 4 - dialeto
+# dialeto
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
 
 # exibir as mensagens de SQL
 spring.jpa.show-sql = true
 
-# delegar para o JPA a cria√ß√£o/atualiza√ß√£o das tabelas
+# delegar para o JPA a criaÁ„o/atualizaÁ„o das tabelas
 spring.jpa.hibernate.ddl-auto = update
 
-# vers√µes spring maiores que 2.5, adicionar essa config para o swagger
+# versıes Spring maiores que 2.5, adicionar essa config para o Swagger
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,19 +1,17 @@
-# 1 - usu√°rio do BD
-spring.datasource.username = ${APP_DB_USER}
+usu·rio do BD
+spring.datasource.username = ${env.APP_DB_USERNAME}
 
-# 2 - senha do BD
+# senha do BD
+spring.datasource.password = ${env.APP_DB_PASSWORD}
 
-spring.datasource.password = ${APP_DB_PASSWORD}
+# string de conex„o com o BD / Cria o BD se n„o existir
+spring.datasource.url = ${env.APP_DB_TEST_URL}
 
-
-# 3 - string de conex√£o com o BD / Cria o BD se n√£o existir
-spring.datasource.url = jdbc:mysql://localhost:3306/meli_fresh_test?createDatabaseIfNotExist=true
-
-# 4 - dialeto
+# dialeto
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
 
 # exibir as mensagens de SQL
 spring.jpa.show-sql = true
 
-# vers√µes spring maiores que 2.5, adicionar essa config para o swagger
-spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
+# versıes Spring maiores que 2.5, adicionar essa config para o Swagger
+sring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -13,5 +13,8 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL8Dialect
 # exibir as mensagens de SQL
 spring.jpa.show-sql = true
 
+# delegar para o JPA a criação/atualização das tabelas
+spring.jpa.hibernate.ddl-auto = update
+
 # versões Spring maiores que 2.5, adicionar essa config para o Swagger
 sring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.profiles.active=${APP_MELI_FRESH:dev}
+spring.profiles.active=${env.APP_MELI_FRESH:dev}


### PR DESCRIPTION
Add the capability to read configurations as environment variables stored in .env files. Uses the most excellent [spring-dotenv library](https://github.com/paulschwarz/spring-dotenv) by Paul Schwarz, which in turn delegates to the (also excellent) [dotenv-java](https://github.com/cdimascio/dotenv-java) library by Carmine DiMascio.

Storing [configuration in the environment](http://12factor.net/config) is one of the tenets of a [twelve-factor app](http://12factor.net/). Anything that is likely to change between deployment environments – such as resource handles for databases or credentials for external services – should be extracted from the code into environment variables.